### PR TITLE
Throw errors and exposing augment function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 _SpecRunner.html
 node_modules
 .idea
+*.swp
+*.swo
+.DS_Store
+*.orig

--- a/spec/augment.spec.js
+++ b/spec/augment.spec.js
@@ -4,6 +4,10 @@
 describe("augment", function() {
   'use strict';
 
+  it("should be available as Backbone.Augment", function(){
+    expect(typeof Backbone.Augment).toEqual("function");
+  });
+
   it("should exist on all core backbone objects", function() {
     expect(typeof Backbone.Model.augment).toEqual('function');
     expect(typeof Backbone.Collection.augment).toEqual('function');

--- a/spec/augment.spec.js
+++ b/spec/augment.spec.js
@@ -38,4 +38,27 @@ describe("augment", function() {
     newViewInstance.foo();
     expect(augmentSpy).toHaveBeenCalled();
   });
+
+  describe("when using an object that does not provide an augment function", function(){
+    var aug = {};
+
+    function run(){
+      Backbone.View.augment(aug);
+    }
+
+    it("should throw an error", function(){
+      expect(run).toThrow("Augmenting object does not provie an `augment` function.");
+    });
+  });
+
+  describe("when specifying an undefined or null object as an augmenter", function(){
+    function run(){
+      Backbone.View.augment(undefined);
+    }
+
+    it("should throw an error", function(){
+      expect(run).toThrow("Specified augmenting object is null or undefined");
+    });
+  });
+
 });

--- a/src/backbone.augment.js
+++ b/src/backbone.augment.js
@@ -13,9 +13,18 @@
     var self = this;
     for (var i = 0; i < arguments.length; i++) {
       var aug = arguments[i];
-      if (aug.augment) {
-        self = aug.augment(self);
+
+      if (!aug){
+        throw new Error("Specified augmenting object is null or undefined");
       }
+
+      if (!aug.augment){
+        var error = Error("Augmenting object does not provie an `augment` function.");
+        error.augmentObject = aug;
+        throw error;
+      }
+
+      self = aug.augment(self);
     }
     return self;
   }

--- a/src/backbone.augment.js
+++ b/src/backbone.augment.js
@@ -9,6 +9,12 @@
 }(this, function (Backbone) {
   "use strict";
 
+  // Augment
+  // -------
+  //
+  // Augment an object with additional functionality, allowing
+  // object composition instead of just inheritance or simple
+  // extend functions
   function augment(/* augments... */) {
     var self = this;
     for (var i = 0; i < arguments.length; i++) {
@@ -29,7 +35,11 @@
     return self;
   }
 
-  Backbone.Model.augment = Backbone.Collection.augment = Backbone.View.augment = augment;
+  Backbone.Augment = 
+    Backbone.Model.augment = 
+    Backbone.Collection.augment = 
+    Backbone.View.augment = 
+    augment;
 
   return augment;
 }));


### PR DESCRIPTION
I started playing with this over the weekend and this morning, and I noticed that I ran into several situations where I got errors that I didn't understand. So I added two guard clauses that check to ensure the object used as an augmenter exists, and that it has an augment function. Each of these clauses throws an error if it fails. This made it easier for me to see where I was going wrong with my experiments.

I also wanted to have the `augment` function available outside of the requirejs module definition, so I exposed it as `Backbone.Augment`.

I have some other ideas on things I want to see as well, but I'll do separate pull requests for them.
