### PR TITLE
Provide a mixInto function to mix a source's functions in to a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,21 @@ var NewView = Backbone.View.extend({ /* new stuff */});
 
 ### Using augment
 
+The `augment` function is available on all of the basic Backbone types
+that you would normal `extend`:
+
+* Backbone.View
+* Backbone.Model
+* Backbone.Collection
+* Backbone.Router
+
+You can call the `augment` function from the type directly, or from the
+`.prototype`, as needed.
+
 ```
 var NewView = Backbone.View.augment(augment1, augment2, etc);
+
+NewView.prototype.augment(augment3, augment4, etc);
 ```
 
 ### Augment with extend

--- a/README.md
+++ b/README.md
@@ -107,6 +107,56 @@ var augment = {
 The important difference is that your implementing augmenter is passed in as an argument, meaning we don't
 know where we're being used. This is an important abstraction point that encourages much more reusable code.
 
+## mixInto
+
+There are times when an augmenting object may not be able to be mixed
+directly in to an object as a whole. For example, if the augmenting object
+contains an `events` definition, it can't be mixed directly in to a
+`Backbone.View` because it would override the view's events definition.
+
+To work around this issue, while still providing the ability to agument
+an object with new functionality, a `mixInto` function has been provided.
+
+This function takes at least three arguments:
+
+* target
+* source
+* method names
+
+When calling a function that has been mixed into a target object, the
+context of that function is set to the original mixin object.
+
+```js
+// define an augmenting object
+aug = {
+
+  augment: function(t){
+
+    // use `mixInto` to agument the target with methods
+    // from this object
+    Backbone.Augment.mixInto(t, this, "foo");
+
+  },
+
+  foo: function(){
+    console.log("I'm the foo function!", this)
+  }
+};
+
+// create a new object type and augment it with the mixin
+Target = Backbone.Model.extend({});
+Target.prototype.augment(aug);
+
+// create an instance of the object and run the function
+// logs the message, and the `aug` function as the context
+target = new Target();
+target.foo(); // => "I'm the foo function!" #<object>
+```
+
+In this example, the `foo` function is mixed in to the target. When
+the foo function is called, it's context is the original `aug` function
+that defined the function.
+
 ## Not just an inverted `extend()`
 
 An augment's sole requirement is that it includes an `augment()` method. This allows you free reign to do

--- a/spec/augment.spec.js
+++ b/spec/augment.spec.js
@@ -12,6 +12,14 @@ describe("augment", function() {
     expect(typeof Backbone.Model.augment).toEqual('function');
     expect(typeof Backbone.Collection.augment).toEqual('function');
     expect(typeof Backbone.View.augment).toEqual('function');
+    expect(typeof Backbone.Router.augment).toEqual('function');
+  });
+
+  it("should exist on all core backbone object prototypes", function() {
+    expect(typeof Backbone.Model.prototype.augment).toEqual('function');
+    expect(typeof Backbone.Collection.prototype.augment).toEqual('function');
+    expect(typeof Backbone.View.prototype.augment).toEqual('function');
+    expect(typeof Backbone.Router.prototype.augment).toEqual('function');
   });
 
   it("should exist on extended objects", function() {

--- a/spec/mixInto.spec.js
+++ b/spec/mixInto.spec.js
@@ -1,0 +1,32 @@
+describe("mix into", function(){
+
+  describe("when mixing a function in to a Target object", function(){
+    var Target, target, aug;
+
+    beforeEach(function(){
+      aug = {
+        augment: function(t){
+          Backbone.Augment.mixInto(t, this, "foo");
+        },
+
+        foo: jasmine.createSpy("foo function")
+      };
+
+      Target = Backbone.Model.extend({});
+      Target.prototype.augment(aug);
+
+      target = new Target();
+      target.foo();
+    });
+   
+    it("should attach that function to the Target", function(){
+      expect(target.foo).not.toBeUndefined();
+    }); 
+    
+    it("should bind that function call to the augmenting object", function(){
+      var context = aug.foo.mostRecentCall.object;
+      expect(context).toBe(aug);
+    });
+  });
+
+});

--- a/src/backbone.augment.js
+++ b/src/backbone.augment.js
@@ -35,11 +35,22 @@
     return self;
   }
 
-  Backbone.Augment = 
-    Backbone.Model.augment = 
-    Backbone.Collection.augment = 
-    Backbone.View.augment = 
-    augment;
+  // Export The API
+  // --------------
+ 
+  Backbone.Augment = augment;
+
+  Backbone.Model.augment = _.bind(augment, Backbone.Model);
+  Backbone.Model.prototype.augment = augment;
+
+  Backbone.Collection.augment = _.bind(augment, Backbone.Collection);
+  Backbone.Collection.prototype.augment = augment;
+
+  Backbone.View.augment = _.bind(augment, Backbone.View);
+  Backbone.View.prototype.augment = augment;
+
+  Backbone.Router.augment = _.bind(augment, Backbone.Router);
+  Backbone.Router.prototype.augment = augment;
 
   return augment;
 }));

--- a/src/backbone.augment.js
+++ b/src/backbone.augment.js
@@ -35,6 +35,32 @@
     return self;
   }
 
+  // Mix Into
+  // --------
+  //
+  // Mix a function from one object in to another, while preserving
+  // the context of the original object when executing the function
+  // on the target.
+
+  augment.mixInto = function(target, source, methodNames){
+    // ignore the actual args list and build from arguments so we can
+    // be sure to get all of the method names
+    var args = Array.prototype.slice.apply(arguments);
+    target = args.shift();
+    source = args.shift();
+    methodNames = args;
+
+    var method;
+    var length = methodNames.length;
+    for(var i = 0; i < length; i++){
+      method = methodNames[i];
+      
+      // bind the function from the source and assign the
+      // bound function to the target
+      target[method] = _.bind(source[method], source);
+    }
+  };
+
   // Export The API
   // --------------
  


### PR DESCRIPTION
As noted in my blog post on Mixins (http://lostechies.com/derickbailey/2012/10/07/javascript-mixins-beyond-simple-object-extension/) I would like to be able to mix a specific function from a source object in to a target object.

I added a `mixInto` function on to `Backbone.Augment` so that this can be done. As an example:

``` js
      aug = {
        augment: function(t){
          Backbone.Augment.mixInto(t, this, "foo");
        },

        foo: function(){
          console.log("I'm the foo function!")
        }
      };

      Target = Backbone.Model.extend({});
      Target.prototype.augment(aug);

      target = new Target();
      target.foo(); // => "I'm the foo function!"
```

In order to make this work the way I would like to see it work, I needed to be able to `augment` a Backbone object's prototype, not just the type itself. As shown in this example, you can now augment a prototype directly:

`Backbone.Model.prototype.augment(...)`

This gives us more flexibility in augmenting either a base Backbone type or it's prototype, explicitly.
